### PR TITLE
Fixed: double click doesn't break the graph and doesn't try to zoom

### DIFF
--- a/server/static/js/force_directed_graph.js
+++ b/server/static/js/force_directed_graph.js
@@ -347,6 +347,7 @@ var ForceDirectedGraph = function(selector, width, height)
 
                 if (source == target)
                 {
+
                     // Values that affect the loop size
                     var relativeMultiplier = link.relativeValue * 2 * circleRadius;
                     // It's a self-link.  So, we make a little loop.
@@ -414,7 +415,8 @@ var ForceDirectedGraph = function(selector, width, height)
             .on("mousedown.zoom", null)
             .on("touchstart.zoom", null)
             .on("touchmove.zoom", null)
-            .on("touchend.zoom", null);
+            .on("touchend.zoom", null)
+            .on("dblclick.zoom", null);
 
         /**
          * "Search" for a particular node.  Highlight that node and the nodes


### PR DESCRIPTION
Very basic fix, which removes the double-click zoom that is apparently the problem. It very specifically only affects double clicking, so it won't have an effect on other zooming methods like pinch zoom on touchscreens.
