### PR TITLE
New: Horizontal bargraphs(single and combined) button toggle

### DIFF
--- a/server/static/js/bargraph.js
+++ b/server/static/js/bargraph.js
@@ -224,7 +224,11 @@ var BarGraph = function(selector, width, height, numericAxis, title)
 
     }
 
+
+
     // GUI components
+    //attachEmptyControlPanel(selector);
+    attachHorizontalButton(selector, chart, editedTitle);
     attachPrintButton(selector, d3.select(selector).select("svg")[0][0], editedTitle);
     attachSortChooser(selector);
 

--- a/server/static/js/bargraph_grouped.js
+++ b/server/static/js/bargraph_grouped.js
@@ -135,6 +135,7 @@ var BarGraphGrouped = function(selector, width, height) {
 
 
     // Draw GUI components
+    attachHorizontalButton(selector, chart)
     attachPrintButton(selector, d3.select(selector).select("svg")[0][0]);
 
 

--- a/server/static/js/utils.js
+++ b/server/static/js/utils.js
@@ -209,8 +209,10 @@ function attachEmptyControlPanel(parentSelector) {
 var attachFileUpload = function(parentSelector, filetype, chart)
 {
     var fileUpload = d3.select(parentSelector)
-        .append("p")
-        .append("form");
+        .append("p");
+
+
+    fileUpload.append("form");
 
     fileUpload.append("label")
         .append("input")
@@ -248,6 +250,52 @@ var attachFileUpload = function(parentSelector, filetype, chart)
             };
         })(file);
         read.readAsText(file);
+
+    })
+}
+
+/**
+ * Attach a horizontal/vertical tilt button to the parent.
+ *
+ * @param parentSelector, whichChart
+ * @returns {*}
+ */
+function attachHorizontalButton(parentSelector, whichChart, title)
+{
+    if (typeof title != "string"){
+        title = "Chart"
+    }
+    var tilt = d3.select(parentSelector)
+        .append("p")
+        .attr("class", title);
+
+
+    tilt.append("label")
+        .append("button")
+        .attr({
+            "name":"tilt",
+            "id":"tilt",
+            "type":"button",
+
+        })
+        .text("Tilt 90 degrees");
+
+
+    tilt.on("click", function(){
+        d3.event.preventDefault();
+        var originalHeight = whichChart.svg.attr("height")
+        if (whichChart.g.attr("transform")=="rotate(90 200 200) translate(40,40)")
+        {
+            whichChart.svg.attr("height", whichChart.svg.attr("width"))
+            whichChart.svg.attr("width", originalHeight)
+            whichChart.g.attr("transform","translate(40,20)");
+        }
+        else{
+            whichChart.svg.attr("height", whichChart.svg.attr("width"))
+            whichChart.svg.attr("width", originalHeight)
+            whichChart.g.attr("transform","rotate(90 200 200) translate(40,40)");
+        }
+
 
     })
 }


### PR DESCRIPTION
Added a button to toggle between vertical and horizontal display of bargraphs (single and clustered). It can fairly easily be added to other types of graphs too (it's in utils).
Closes #102 and #111 
